### PR TITLE
fix harmonic annotations on higher frequency scales

### DIFF
--- a/signal_analyser/__init__.py
+++ b/signal_analyser/__init__.py
@@ -362,7 +362,8 @@ class signal_analyser(thesdk):
             peak_idcs = ss.find_peaks(tmppsd,distance=2)[0]
             peaks_sorted = np.flipud(np.sort(tmppsd[peak_idcs]))
             self.sigidx = np.where(tmppsd == peaks_sorted[0])[0][0]
-            self.sigfreq = tmpfreq[np.where(tmppsd == peaks_sorted[0])[0][0]]
+            self.sigfreq = round(tmpfreq[np.where(tmppsd == peaks_sorted[0])[0][0]], int('{:.1e}'.format(self.xscale).split('-')[-1]))
+
             self.sfdr = peaks_sorted[0]-peaks_sorted[1]
             self.spuridx = np.where(tmppsd == peaks_sorted[1])[0][0]
             self.spurfreq = tmpfreq[self.spuridx]

--- a/signal_analyser/__init__.py
+++ b/signal_analyser/__init__.py
@@ -299,7 +299,7 @@ class signal_analyser(thesdk):
                 rem = fharm % (self.fs_scaled/2)
                 alias = np.floor(fharm/(self.fs_scaled/2))
                 if alias % 2 == 0:
-                    self.harmidcs[i] = np.where(freq_axis >= rem)[0][0]
+                    self.harmidcs[i] = np.argmin(abs(freq_axis - rem))
                 else:
                     self.harmidcs[i] = np.where(freq_axis >= self.fs_scaled/2-rem)[0][0]
                 hd_pow = psd[self.harmidcs[i]]
@@ -362,8 +362,7 @@ class signal_analyser(thesdk):
             peak_idcs = ss.find_peaks(tmppsd,distance=2)[0]
             peaks_sorted = np.flipud(np.sort(tmppsd[peak_idcs]))
             self.sigidx = np.where(tmppsd == peaks_sorted[0])[0][0]
-            self.sigfreq = round(tmpfreq[np.where(tmppsd == peaks_sorted[0])[0][0]], int('{:.1e}'.format(self.xscale).split('-')[-1]))
-
+            self.sigfreq = tmpfreq[np.argmin(abs(tmppsd-peaks_sorted[0]))]
             self.sfdr = peaks_sorted[0]-peaks_sorted[1]
             self.spuridx = np.where(tmppsd == peaks_sorted[1])[0][0]
             self.spurfreq = tmpfreq[self.spuridx]
@@ -779,7 +778,6 @@ if __name__=="__main__":
         self.print_log(type='W',msg='Module \'plot_format\' not in path. Plot formatting might look incorrect.')
 
     fs=2e9
-    #f = 75.1953125e6
     f = 700.1953125e6
     nsamp = 2**12
     t = np.linspace(0,nsamp/fs,num=nsamp,endpoint=False)
@@ -791,7 +789,7 @@ if __name__=="__main__":
 
     duts=[signal_analyser() for i in range(1) ]
     duts[0].model='py'
-    for d in duts: 
+    for d in duts:
         d.fs = fs
         d.nsamp = nsamp
         d.window = False
@@ -806,4 +804,3 @@ if __name__=="__main__":
         d.init()
         d.run()
     input()
-


### PR DESCRIPTION
Solution to the Issue #5 "Missing annotations".

If frequency scale is set large in comparison to the fundamental frequency (i.e. GHz with a megahertz range fundamental), the floating point values will cause the harmonics not to be found in add_harmonic_annotation function. 

The problem:
line 365: results into a float with floating point precision error.
lines 298 to 304: calculates the indices of harmonics using the errorous float resulting into high indices (intended + 1).
line 497: the resulted errorous indices do not have enough power to be over the baseline => nothing is annotated.

The solution: (EDIT: THIS WAS NOT THE WAY, PLEASE CHECK FURTHER COMMENTS)
line 365: round the resulted fundamental frequency value based on the frequency scale.

If there is better way of implementing this, please tell. Also, everyone that can (@sporrasm, @vlahtin), please test this to see nothing is broken. IF this breaks something, it may affect calculation of harmonic frequencies and powers, and annotations of the plot via self.sigfreq.