### PR TITLE
fix harmonics over xlim

### DIFF
--- a/signal_analyser/__init__.py
+++ b/signal_analyser/__init__.py
@@ -494,6 +494,9 @@ class signal_analyser(thesdk):
                 idx = int(self.harmidcs[i])
                 self.harmpowers.append(psd[idx])
                 if self.annotate_harmonics and psd[idx] > baseline:
+                    if self.xlim:
+                        if self.xlim < freq_axis[idx]:
+                            continue
                     #harmtxt = "-%.02f dBc" % -psd[harmonics[i]]
                     harmtxt = "H%d" % (i+2)
                     fontsize = plt.rcParams['xtick.labelsize']


### PR DESCRIPTION
If plotting a spectrum with xlim, and using annotate_harmonics, the user may get figure like this using export:

<img width="637" height="172" alt="spectrum_broken" src="https://github.com/user-attachments/assets/327dee6d-a5a8-4171-9b87-d84b7e01a881" />

This would be simply fixed with
```
                    if self.xlim:
                        if self.xlim < freq_axis[idx]:
                            continue
```
 when looping through the harmonics, i.e. skipping the annotations from harmonics that fall outside the image. Then resulting into an exported figure like so:

<img width="330" height="167" alt="spectrum_fixed" src="https://github.com/user-attachments/assets/29fb5fd0-cda0-4461-920e-93e6ae1610ad" />

The user could also reduce the amount of annotated harmonics, so this is not very critical bug, but nevertheless, I think xlim should cut off everything from the image after its value. 